### PR TITLE
Exclude comments from strings

### DIFF
--- a/bst.sublime-syntax
+++ b/bst.sublime-syntax
@@ -55,6 +55,7 @@ contexts:
 
   string:
     - meta_scope: string.quoted.double.tex
+    - meta_include_prototype: false
     - match: '"'
       pop: true
 


### PR DESCRIPTION
A `%` in a string would comment the rest of the line, including the closing `"` causing the rest of the file to be recognised as a string. By excluding the prototype in strings we avoid doing any parsing in strings except catching the closing quote.